### PR TITLE
Add missing header file for GEO cam config

### DIFF
--- a/src/cpp/geocam_cfg.h
+++ b/src/cpp/geocam_cfg.h
@@ -1,0 +1,3 @@
+#define GEO_CAM_WIDTH   1920
+#define GEO_CAM_HEIGHT  1080
+#define GEO_CAM_SOCK    "/var/run/madmux/ch3.sock"


### PR DESCRIPTION
This got lost in a previous merge and the repo fails when you build it with `-DUSE_MADMUX=1`
Now it passes :)